### PR TITLE
Add delay

### DIFF
--- a/postHandler.js
+++ b/postHandler.js
@@ -7,7 +7,7 @@ const rmdir = require('rimraf')
 const title = 'CSV Uploader for Watson Discovery Service'
 
 
-var interval = 0.05 * 1000; // 0.05 second;
+var interval = 0.1 * 1000; // 0.1 second;
 
 module.exports = (req, res, next) => {
   const b = req.body
@@ -23,7 +23,7 @@ module.exports = (req, res, next) => {
   // `i` is only passed when sendFile is called in a loop,
   // we have a default value so the check the callback evaluates to true
   const sendFile = (path, i = -1) => {
-  // add 1 second delay per loop iteration to prevent timeout of discovery
+  // add 0.1 second delay per loop iteration to prevent timeout of discovery
      setTimeout( function (i) {
     const file = fs.createReadStream(path)
     discovery.addDocument({

--- a/postHandler.js
+++ b/postHandler.js
@@ -6,6 +6,9 @@ const rmdir = require('rimraf')
 
 const title = 'CSV Uploader for Watson Discovery Service'
 
+
+var interval = 1 * 1000; // 1 second;
+
 module.exports = (req, res, next) => {
   const b = req.body
   const jsonFilePaths = []
@@ -20,6 +23,8 @@ module.exports = (req, res, next) => {
   // `i` is only passed when sendFile is called in a loop,
   // we have a default value so the check the callback evaluates to true
   const sendFile = (path, i = -1) => {
+  // add 1 second delay per loop iteration to prevent timeout of discovery
+     setTimeout( function (i) {}
     const file = fs.createReadStream(path)
     discovery.addDocument({
       collection_id: b.collection_id,
@@ -35,6 +40,7 @@ module.exports = (req, res, next) => {
         res.render('index', { title, err, response })
       }
     })
+    }, interval * i, i);
   }
 
   // read csv file and convert csv rows into individual json files

--- a/postHandler.js
+++ b/postHandler.js
@@ -7,7 +7,7 @@ const rmdir = require('rimraf')
 const title = 'CSV Uploader for Watson Discovery Service'
 
 
-var interval = 1 * 1000; // 1 second;
+var interval = 0.05 * 1000; // 0.05 second;
 
 module.exports = (req, res, next) => {
   const b = req.body
@@ -24,7 +24,7 @@ module.exports = (req, res, next) => {
   // we have a default value so the check the callback evaluates to true
   const sendFile = (path, i = -1) => {
   // add 1 second delay per loop iteration to prevent timeout of discovery
-     setTimeout( function (i) {}
+     setTimeout( function (i) {
     const file = fs.createReadStream(path)
     discovery.addDocument({
       collection_id: b.collection_id,


### PR DESCRIPTION
Hi dogsGhost, 

I've added a 01second delay to the loop. I found that when uploading large CSVs (>100 records) Discovery would always timeout. 

Also, when I originally installed I had an issue where npm start was failing because .tmp/json/ was missing. 

Cheers
Nick